### PR TITLE
Fix _scandir bug

### DIFF
--- a/fs_gcsfs/_gcsfs.py
+++ b/fs_gcsfs/_gcsfs.py
@@ -186,14 +186,12 @@ class GCSFS(FS):
         dir_key = self._path_to_dir_key(_path)
 
         if dir_key == "/":
-            # In case we want to list the root directory, no prefix is necessary
-            prefix = ""
-        else:
-            prefix = dir_key
-        prefix_len = len(prefix)
+            # In case we want to list the bucket, dir_key needs to be the empty string
+            dir_key = ""
+        prefix_len = len(dir_key)
 
         # Build set of root level directories
-        page_iterator = self.bucket.list_blobs(prefix=prefix, delimiter="/")
+        page_iterator = self.bucket.list_blobs(prefix=dir_key, delimiter="/")
         prefixes = set()
         for page in page_iterator.pages:
             prefixes.update(page.prefixes)

--- a/fs_gcsfs/tests/test_gcsfs.py
+++ b/fs_gcsfs/tests/test_gcsfs.py
@@ -55,7 +55,6 @@ def tmp_gcsfs(bucket, client):
 
 class TestGCSFS:
 
-    @pytest.mark.skip("There is still a bug in the scandir implementaion. Root level blobs (which are not directories) are not listed")
     def test_scandir_works_on_bucket_as_root_directory(self, client):
         gcs_fs = GCSFS(bucket_name=TEST_BUCKET, client=client)
         path = str(uuid.uuid4())


### PR DESCRIPTION
This PR fixes a bug in the _scandir implementation. As a result of this bug _scandir did not list files at the root_path of the file-system, when the root_path of the file-system was identical to the top-level of the GCS bucket.