### PR TITLE
Releasing 0.4.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,14 @@ Possible types of changes are:
 Unreleased
 ----------
 
+0.4.2 - 30.08.2019
+------------------
+
+Fixed
+'''''
+- Fixed a bug where the url parameter ``strict`` was not considered by GCSFS, e.g. in ``open_fs("gs://bucket_name?strict=False")``
+
+
 0.4.1 - 18.12.2018
 ------------------
 

--- a/fs_gcsfs/opener.py
+++ b/fs_gcsfs/opener.py
@@ -22,4 +22,9 @@ class GCSFSOpener(Opener):
         if not bucket_name:
             raise OpenerError("invalid bucket name in '{}'".format(fs_url))
 
-        return GCSFS(bucket_name, root_path=root_path, create=create)
+        if parse_result.params.get("strict") == "False":
+            strict = False
+        else:
+            strict = True
+
+        return GCSFS(bucket_name, root_path=root_path, create=create, strict=strict)

--- a/fs_gcsfs/tests/test_gcsfs.py
+++ b/fs_gcsfs/tests/test_gcsfs.py
@@ -3,6 +3,7 @@ import unittest
 import uuid
 
 import pytest
+from fs import open_fs
 from fs.errors import IllegalBackReference, CreateFailed
 from fs.test import FSTestCases
 from google.cloud.storage import Client
@@ -161,3 +162,15 @@ def test_instantiation_fails_if_no_access_to_bucket():
 def test_instantiation_with_create_false_fails_for_non_existing_root_path():
     with pytest.raises(CreateFailed):
         GCSFS(bucket_name=TEST_BUCKET, root_path=str(uuid.uuid4()), create=False)
+
+
+@pytest.mark.parametrize("query_param, strict", [
+    ("", True),
+    ("nonExisting=True", True),
+    ("strict=True", True),
+    ("strict=False", False)
+])
+def test_open_fs_url_strict_parameter_works(query_param, strict):
+    fs = open_fs("gs://{}?{}".format(TEST_BUCKET, query_param))
+    assert fs.strict == strict
+


### PR DESCRIPTION
Fixed a bug where the url parameter "strict" was not considered by GCSFS, e.g. in open_fs("gs://bucket_name?strict=False")

Resolves #11