### PR TITLE
Correctly raise ResourceNotFound exception

### DIFF
--- a/fs_gcsfs/_gcsfs.py
+++ b/fs_gcsfs/_gcsfs.py
@@ -352,7 +352,7 @@ class GCSFS(FS):
         gcs_file = GCSFile.factory(path, _mode, on_close=on_close)
         blob = self._get_blob(_key)
         if not blob:
-            raise errors.ResourceNotFound
+            raise errors.ResourceNotFound(path)
 
         blob.download_to_file(gcs_file.raw)
         gcs_file.seek(0)


### PR DESCRIPTION
This fixes a bug in the `open_bin` function, where a `TypeError` in the statement that should raise a `ResourceNotFoundError`.

Steps to reproduce:
```
from fs_gcsfs import GCSFS
import io
filesystem = GCSFS("cloud-ml-data", strict=False)
buf = io.BytesIO()
filesystem.download(path='some_non_existing_path', file=buf)
```
Output without the fix
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-4888058ea69f> in <module>
      3 filesystem = GCSFS("cloud-ml-data", strict=False)
      4 buf = io.BytesIO()
----> 5 filesystem.download(path='some_non_existing_path', file=buf)

~/src/gcsfs/venv/lib/python3.6/site-packages/fs/base.py in download(self, path, file, chunk_size, **options)
    634         """
    635         with self._lock:
--> 636             with self.openbin(path, **options) as read_file:
    637                 tools.copy_file_data(read_file, file, chunk_size=chunk_size)
    638

~/src/gcsfs/fs_gcsfs/_gcsfs.py in openbin(self, path, mode, buffering, **options)
    353         blob = self._get_blob(_key)
    354         if not blob:
--> 355             raise errors.ResourceNotFound
    356
    357         blob.download_to_file(gcs_file.raw)

TypeError: __init__() missing 1 required positional argument: 'path'
```

Output with the fix:
```
---------------------------------------------------------------------------
ResourceNotFound                          Traceback (most recent call last)
<ipython-input-1-4888058ea69f> in <module>
      3 filesystem = GCSFS("cloud-ml-data", strict=False)
      4 buf = io.BytesIO()
----> 5 filesystem.download(path='some_non_existing_path', file=buf)

~/src/gcsfs/venv/lib/python3.6/site-packages/fs/base.py in download(self, path, file, chunk_size, **options)
    634         """
    635         with self._lock:
--> 636             with self.openbin(path, **options) as read_file:
    637                 tools.copy_file_data(read_file, file, chunk_size=chunk_size)
    638

~/src/gcsfs/fs_gcsfs/_gcsfs.py in openbin(self, path, mode, buffering, **options)
    353         blob = self._get_blob(_key)
    354         if not blob:
--> 355             raise errors.ResourceNotFound(path)
    356
    357         blob.download_to_file(gcs_file.raw)

ResourceNotFound: resource 'some_non_existing_path' not found
```