### PR TITLE
Beta version of retry mechanism

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,15 @@ Possible types of changes are:
 Unreleased
 ----------
 
+Added
+'''''
+- Experimental: Clients now automatically retry GCS requests that return with "503 Service Unavailable" or "504 Gateway Timeout.
+
+Fixed
+'''''
+- Some tests were still calling ``get_bucket()`` from the constructor of ``GCSFS``.
+
+
 1.3.0 - 20.05.2020
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ Possible types of changes are:
 Unreleased
 ----------
 
+1.4.0 - 12.06.2020
+------------------
+
 Changed
 '''''''
 - The underlying HTTP client is now configured to automatically retry requests that return a status code of "429 Too Many Requests", "502 Bad Gateway", "503 Service Unavailable" and "504 Gateway Timeout".

--- a/fs_gcsfs/_gcsfs.py
+++ b/fs_gcsfs/_gcsfs.py
@@ -75,7 +75,10 @@ class GCSFS(FS):
         if self.client is None:
             self.client = Client()
             if retry:
-                adapter = HTTPAdapter(max_retries=Retry(total=retry, status_forcelist=[429, 503, 504], method_whitelist=False))
+                adapter = HTTPAdapter(max_retries=Retry(total=retry,
+                                                        status_forcelist=[429, 502, 503, 504],
+                                                        method_whitelist=False,  # retry on any HTTP method
+                                                        backoff_factor=0.5))
                 self.client._http.mount("https://", adapter)
 
         self.bucket = self.client.bucket(self._bucket_name)

--- a/fs_gcsfs/_gcsfs.py
+++ b/fs_gcsfs/_gcsfs.py
@@ -74,12 +74,13 @@ class GCSFS(FS):
         self.client = client
         if self.client is None:
             self.client = Client()
-            if retry:
-                adapter = HTTPAdapter(max_retries=Retry(total=retry,
-                                                        status_forcelist=[429, 502, 503, 504],
-                                                        method_whitelist=False,  # retry on any HTTP method
-                                                        backoff_factor=0.5))
-                self.client._http.mount("https://", adapter)
+        
+        if retry:
+            adapter = HTTPAdapter(max_retries=Retry(total=retry,
+                                                    status_forcelist=[429, 502, 503, 504],
+                                                    method_whitelist=False,  # retry on any HTTP method
+                                                    backoff_factor=0.5))
+            self.client._http.mount("https://", adapter)
 
         self.bucket = self.client.bucket(self._bucket_name)
 

--- a/fs_gcsfs/_gcsfs.py
+++ b/fs_gcsfs/_gcsfs.py
@@ -74,7 +74,7 @@ class GCSFS(FS):
         self.client = client
         if self.client is None:
             self.client = Client()
-        
+
         if retry:
             adapter = HTTPAdapter(max_retries=Retry(total=retry,
                                                     status_forcelist=[429, 502, 503, 504],

--- a/fs_gcsfs/_gcsfs.py
+++ b/fs_gcsfs/_gcsfs.py
@@ -19,6 +19,9 @@ from fs.subfs import SubFS
 from fs.time import datetime_to_epoch
 from google.cloud.storage import Client
 from google.cloud.storage.blob import Blob
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
 
 __all__ = ["GCSFS"]
 
@@ -57,6 +60,7 @@ class GCSFS(FS):
                  root_path: str = None,
                  create: bool = False,
                  client: Client = None,
+                 retry: int = 5,
                  strict: bool = True):
         super().__init__()
         self._bucket_name = bucket_name
@@ -70,6 +74,9 @@ class GCSFS(FS):
         self.client = client
         if self.client is None:
             self.client = Client()
+            if retry:
+                adapter = HTTPAdapter(max_retries=Retry(total=retry, status_forcelist=[429, 503, 504], method_whitelist=False))
+                self.client._http.mount("https://", adapter)
 
         self.bucket = self.client.bucket(self._bucket_name)
 

--- a/fs_gcsfs/tests/conftest.py
+++ b/fs_gcsfs/tests/conftest.py
@@ -14,7 +14,7 @@ def client():
 
 @pytest.fixture(scope="module")
 def bucket(client):
-    return client.get_bucket(os.environ['TEST_BUCKET'])
+    return client.bucket(os.environ['TEST_BUCKET'])
 
 
 @pytest.fixture(scope="function")

--- a/fs_gcsfs/tests/test_gcsfs.py
+++ b/fs_gcsfs/tests/test_gcsfs.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 import uuid
+from unittest import mock
 
 import pytest
 from fs import open_fs
@@ -41,6 +42,10 @@ def client_mock():
 
         def bucket(self, _):
             pass
+
+        @property
+        def _http(self):
+            return mock.MagicMock()
 
     return ClientMock()
 

--- a/fs_gcsfs/tests/test_gcsfs.py
+++ b/fs_gcsfs/tests/test_gcsfs.py
@@ -18,7 +18,7 @@ class TestGCSFS(FSTestCases, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.client = Client()
-        cls.bucket = cls.client.get_bucket(TEST_BUCKET)
+        cls.bucket = cls.client.bucket(TEST_BUCKET)
         super().setUpClass()
 
     def setUp(self):


### PR DESCRIPTION
Experimental: Clients now automatically retry GCS requests that return with "503 Service Unavailable" or "504 Gateway Timeout.