### PR TITLE
Change keyword argument `method_whitelist` to `allowed_methods`

### DIFF
--- a/fs_gcsfs/_gcsfs.py
+++ b/fs_gcsfs/_gcsfs.py
@@ -78,7 +78,7 @@ class GCSFS(FS):
         if retry:
             adapter = HTTPAdapter(max_retries=Retry(total=retry,
                                                     status_forcelist=[429, 502, 503, 504],
-                                                    method_whitelist=False,  # retry on any HTTP method
+                                                    allowed_methods=False,  # retry on any HTTP method
                                                     backoff_factor=0.5))
             self.client._http.mount("https://", adapter)
 


### PR DESCRIPTION
Fixes #38. The `method_whitelist` keyword will be deprecated in the GCSFS dependency `urllib3`.