### PR TITLE
Expose 'mode' attribute to be interface compliant

### DIFF
--- a/fs_gcsfs/_gcsfs.py
+++ b/fs_gcsfs/_gcsfs.py
@@ -602,6 +602,10 @@ class GCSFile(io.IOBase):
     def writelines(self, lines):
         return self._f.writelines(lines)
 
+    @property
+    def mode(self):
+        return self.__mode.to_platform_bin()
+
     def read(self, n=-1):
         if not self.__mode.reading:
             raise IOError("not open for reading")


### PR DESCRIPTION
Pyfilesystem requires that proxy classes such as `GCSFile` expose a `mode` attribute and this has been enforced in the test suite of the most recent release (2.4.12).

This changeset implements the mode attribute on `GCSFile`.