### PR TITLE
Fix infinite loop in directory discovery

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,22 @@ Possible types of changes are:
 
 
 
+Unreleased
+----------
+Fixed
+'''''
+- Infinite loop in ``GCSFS.fix_storage()`` when the bucket contains blobs or
+  directories (with or without empty blob) on the same hierarchy level as
+  ``root_path`` and whose name also starts with the ``root_path`` directory
+  name. For example, having ``root_path = "gs://mybucket/abc"`` and these
+  blobs in the bucket:
+
+  .. code-block::
+
+      gs://mybucket/abc/file.txt
+      gs://mybucket/abc123/file.txt
+
+
 1.5.1 - 03.06.2022
 ------------------
 Fixed

--- a/fs_gcsfs/_gcsfs.py
+++ b/fs_gcsfs/_gcsfs.py
@@ -481,7 +481,7 @@ class GCSFS(FS):
         As GCS is no real file system but only a key-value store, there is also no concept of folders. S3FS and GCSFS overcome this limitation by adding
         empty files with the name "<path>/" every time a directory is created, see https://fs-gcsfs.readthedocs.io/en/latest/#limitations.
         """
-        names = [blob.name for blob in self.bucket.list_blobs(prefix=self.root_path)]
+        names = [blob.name for blob in self.client.list_blobs(self.bucket, prefix=forcedir(self.root_path))]
         marked_dirs = set()
         all_dirs = set()
 


### PR DESCRIPTION
The `fix_storage` method enters an infinite loop when there are other directories that have `root_path` as prefix.

For example, if the contents of the bucket look like this:
```
gs://mybucket/abc/file.txt
gs://mybucket/abc123/file.txt
```

this code results in an infinite loop:
```python
from fs import open_fs
open_fs("gs://mybucket/abc?strict=False").fix_storage()
```

In order to avoid this, we need to ensure `root_path` has a trailing "/", when listing blobs, which prevents "abc123/file.txt" from being listed as child of "abc".

Additionally, `Bucket.list_blobs` was deprecated in favor of `Client.list_blobs` (see [reference documentation][1]).

[1]: https://cloud.google.com/python/docs/reference/storage/1.44.0/buckets#listblobsmaxresultsnone-pagetokennone-prefixnone-delimiternone-startoffsetnone-endoffsetnone-includetrailingdelimiternone-versionsnone-projectionnoacl-fieldsnone-clientnone-timeout60-retrygoogleapicoreretryretry-object

---

Grüße aus Berlin