### PR TITLE
Safety check for valid root_path

### DIFF
--- a/fs_gcsfs/_gcsfs.py
+++ b/fs_gcsfs/_gcsfs.py
@@ -70,6 +70,8 @@ class GCSFS(FS):
         if not root_path:
             root_path = ""
         self.root_path = root_path
+        if self.root_path.endswith("/"):
+            raise ValueError("root_path must not end with a slash")
         self._prefix = relpath(normpath(root_path)).rstrip(self.DELIMITER)
 
         self.strict = strict


### PR DESCRIPTION
If the root_path has a trailing slash, fix_storage will encounter an infinite loop. To prevent this, we prohibit the root_path having a trailing slash.
Closes #55 