### PR TITLE
Create PEP518-compliant pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools_scm"]


### PR DESCRIPTION
For PEP518 compliancy. This allows tools like Pants v2 to properly lock this dependency. Without it, you get an error like this:

```
❯ pants generate-lockfiles
22:45:49.88 [INFO] Completed: Generate lockfile for python-default
22:45:49.88 [ERROR] 1 Exception encountered:

Engine traceback:
  in `generate-lockfiles` goal

ProcessExecutionFailure: Process 'Generate lockfile for python-default' failed with exit code 1.
stdout:

stderr:
No distribution metadata found for fs-gcsfs==1.5.1.
```